### PR TITLE
move folding styles into separate css file

### DIFF
--- a/instruction-folding.css
+++ b/instruction-folding.css
@@ -1,0 +1,7 @@
+.setter {
+    padding:0.3em;
+    text-decoration:underline;
+}
+.setter-active{
+    background-color:#FFFF99;
+}

--- a/styles.css
+++ b/styles.css
@@ -2,10 +2,3 @@ body {
 	font-family: sans-serif;
 	line-height: 1.5em;
 }
-.setter {
-	padding:0.3em;
-	text-decoration:underline;
-}
-.setter-active{
-	background-color:#FFFF99;
-}

--- a/testtext.html
+++ b/testtext.html
@@ -7,6 +7,7 @@
   <title>Conditional Text Test</title>
   <meta name="generator" content="Bluefish 2.2.5" />
   <link href="styles.css" rel="stylesheet" type="text/css" />
+  <link href="instruction-folding.css" rel="stylesheet" type="text/css" />
   <script type="text/javascript" src="instruction-folding.js"></script>
 </head>
 


### PR DESCRIPTION
Moving this into a separate file makes inclusion easier, as it doesn't mess up the including projects body styles.
